### PR TITLE
[feat] 캘린더 VC 작업

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		005AF798283B775300546D5B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 005AF797283B775300546D5B /* Assets.xcassets */; };
 		005AF7A6283B775300546D5B /* AirbnbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005AF7A5283B775300546D5B /* AirbnbTests.swift */; };
 		00863C4D284609DD004E5954 /* CalendarHearderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C4C284609DD004E5954 /* CalendarHearderView.swift */; };
+		00863C4F2847452F004E5954 /* CalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C4E2847452F004E5954 /* CalendarModel.swift */; };
+		00863C5128474614004E5954 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C5028474614004E5954 /* Day.swift */; };
+		00863C5328474792004E5954 /* MonthMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C5228474792004E5954 /* MonthMetadata.swift */; };
 		008A2062283F4E220095F7BC /* BackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2061283F4E220095F7BC /* BackgroundViewController.swift */; };
 		008A2064283F62910095F7BC /* LocationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */; };
 		008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A20A5283FE3960095F7BC /* HeaderReusableView.swift */; };
@@ -92,6 +95,9 @@
 		005AF7A5283B775300546D5B /* AirbnbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbTests.swift; sourceTree = "<group>"; };
 		005AF7AB283B775300546D5B /* AirbnbUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirbnbUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00863C4C284609DD004E5954 /* CalendarHearderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHearderView.swift; sourceTree = "<group>"; };
+		00863C4E2847452F004E5954 /* CalendarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarModel.swift; sourceTree = "<group>"; };
+		00863C5028474614004E5954 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
+		00863C5228474792004E5954 /* MonthMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthMetadata.swift; sourceTree = "<group>"; };
 		008A2061283F4E220095F7BC /* BackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewController.swift; sourceTree = "<group>"; };
 		008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCollectionViewCell.swift; sourceTree = "<group>"; };
 		008A20A5283FE3960095F7BC /* HeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderReusableView.swift; sourceTree = "<group>"; };
@@ -268,6 +274,8 @@
 				0029729528445B8D0033437E /* LocationModel.swift */,
 				1B27E234283CA44400FCB990 /* SearchViewModel.swift */,
 				1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */,
+				00863C4E2847452F004E5954 /* CalendarModel.swift */,
+				00863C5228474792004E5954 /* MonthMetadata.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -350,6 +358,7 @@
 			isa = PBXGroup;
 			children = (
 				1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */,
+				00863C5028474614004E5954 /* Day.swift */,
 				1BF0618728459A210043FF2F /* Reservations.swift */,
 			);
 			path = DTO;
@@ -511,10 +520,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				0029729C2844B4DF0033437E /* CalendarViewController.swift in Sources */,
+				00863C5328474792004E5954 /* MonthMetadata.swift in Sources */,
 				00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */,
 				1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */,
 				1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */,
 				0029729628445B8D0033437E /* LocationModel.swift in Sources */,
+				00863C4F2847452F004E5954 /* CalendarModel.swift in Sources */,
 				1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */,
 				00A85F35283B872800EA32E0 /* ReservationModel.swift in Sources */,
 				00A85F3C283B876A00EA32E0 /* WishListViewController.swift in Sources */,
@@ -537,6 +548,7 @@
 				00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,
+				00863C5128474614004E5954 /* Day.swift in Sources */,
 				1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */,
 				1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */,
 				1BF061902845F31E0043FF2F /* CommonColors.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Search/BackgroundViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/BackgroundViewController.swift
@@ -22,6 +22,7 @@ class BackgroundViewController: UIViewController {
     }
     
     private func setUpNavigationAppearance() {
+        navigationItem.backButtonTitle = "뒤로"
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = .systemGray6
@@ -30,7 +31,7 @@ class BackgroundViewController: UIViewController {
     }
     
     private func setUpToolBarAppearance() {
-        navigationController?.toolbar.tintColor = .black
+        navigationController?.toolbar.tintColor = .label
         let toolBarAppearance = UIToolbarAppearance()
         toolBarAppearance.configureWithOpaqueBackground()
         toolBarAppearance.backgroundColor = .systemGray6

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarHearderView.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarHearderView.swift
@@ -6,13 +6,60 @@
 //
 
 import UIKit
+import SnapKit
 
 class CalendarHearderView: UICollectionReusableView {
-//    override var reuseIdentifier: String?
+    
+    var baseDate: Date? {
+        didSet {
+            guard let date = baseDate else { return }
+            yearMonthLabel.text = dateFormatter.string(from: date)
+        }
+    }
+    
+    private lazy var dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 M월"
+        return dateFormatter
+    }()
+    
+    private let yearMonthLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 17, weight: .bold)
+        label.accessibilityTraits = .header
+        label.isAccessibilityElement = true
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        addSubview(yearMonthLabel)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        yearMonthLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        yearMonthLabel.text = nil
+    }
 }
 
 extension UICollectionReusableView {
-//    static var reuseIdentifier: String { String(describing: Self.self) }
+    static var reuseIdentifier: String { String(describing: Self.self) }
 }
-
 

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
@@ -10,114 +10,123 @@ import UIKit
 class CalendarViewCell: UICollectionViewCell {
     
     var day: Day? {
-      didSet {
-        guard let day = day else { return }
-
-        numberLabel.text = day.number
-        accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
-        updateSelectionStatus()
-      }
+        didSet {
+            guard let day = day else { return }
+            if day.isWithInDisplayedMonth {
+                numberLabel.text = day.number
+                accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
+                updateSelectionStatus()
+            } else {
+                selectionBackgroundView.isHidden = true
+            }
+        }
     }
-
+    
     
     private lazy var selectionBackgroundView: UIView = {
-      let view = UIView()
-      view.translatesAutoresizingMaskIntoConstraints = false
-      view.clipsToBounds = true
-      view.backgroundColor = .systemRed
-      return view
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = true
+        view.backgroundColor = .gray1
+        return view
     }()
-
+    
     private lazy var numberLabel: UILabel = {
-      let label = UILabel()
-      label.translatesAutoresizingMaskIntoConstraints = false
-      label.textAlignment = .center
-      label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
-      label.textColor = .label
-      return label
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
+        label.textColor = .label
+        return label
     }()
-
+    
     private lazy var accessibilityDateFormatter: DateFormatter = {
-      let dateFormatter = DateFormatter()
-      dateFormatter.calendar = Calendar(identifier: .gregorian)
-      dateFormatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d")
-      return dateFormatter
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d")
+        return dateFormatter
     }()
-
+    
     override init(frame: CGRect) {
-      super.init(frame: frame)
-
-      isAccessibilityElement = true
-      accessibilityTraits = .button
-      contentView.addSubview(selectionBackgroundView)
-      contentView.addSubview(numberLabel)
+        super.init(frame: frame)
+        
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        contentView.addSubview(selectionBackgroundView)
+        contentView.addSubview(numberLabel)
     }
-
+    
     required init?(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func layoutSubviews() {
-      super.layoutSubviews()
-
-      NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
-
-      let size = traitCollection.horizontalSizeClass == .compact ?
+        super.layoutSubviews()
+        
+        NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
+        
+        let size = traitCollection.horizontalSizeClass == .compact ?
         min(min(frame.width, frame.height) - 10, 60) : 45
-
-      NSLayoutConstraint.activate([
-        numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-        numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-
-        selectionBackgroundView.centerYAnchor
-          .constraint(equalTo: numberLabel.centerYAnchor),
-        selectionBackgroundView.centerXAnchor
-          .constraint(equalTo: numberLabel.centerXAnchor),
-        selectionBackgroundView.widthAnchor.constraint(equalToConstant: size),
-        selectionBackgroundView.heightAnchor
-          .constraint(equalTo: selectionBackgroundView.widthAnchor)
-      ])
-
-      selectionBackgroundView.layer.cornerRadius = size / 2
-
+        
+        NSLayoutConstraint.activate([
+            numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            
+            selectionBackgroundView.centerYAnchor
+                .constraint(equalTo: numberLabel.centerYAnchor),
+            selectionBackgroundView.centerXAnchor
+                .constraint(equalTo: numberLabel.centerXAnchor),
+            selectionBackgroundView.widthAnchor.constraint(equalToConstant: size),
+            selectionBackgroundView.heightAnchor
+                .constraint(equalTo: selectionBackgroundView.widthAnchor)
+        ])
+        
+        selectionBackgroundView.layer.cornerRadius = size / 2
+        
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        numberLabel.text = nil
     }
 }
 
 // MARK: - Appearance
 private extension CalendarViewCell {
-  
-  func updateSelectionStatus() {
-    guard let day = day else { return }
-
-    if day.isSelected {
-      applySelectedStyle()
-    } else {
-        applyDefaultStyle()
+    
+    func updateSelectionStatus() {
+        guard let day = day else { return }
+        
+        if day.isSelected {
+            applySelectedStyle()
+        } else {
+            applyDefaultStyle()
+        }
     }
-  }
-
-  var isSmallScreenSize: Bool {
-    let isCompact = traitCollection.horizontalSizeClass == .compact
-    let smallWidth = UIScreen.main.bounds.width <= 350
-    let widthGreaterThanHeight =
-      UIScreen.main.bounds.width > UIScreen.main.bounds.height
-
-    return isCompact && (smallWidth || widthGreaterThanHeight)
-  }
-
-  func applySelectedStyle() {
-    accessibilityTraits.insert(.selected)
-    accessibilityHint = nil
-
-    numberLabel.textColor = isSmallScreenSize ? .systemRed : .white
-    selectionBackgroundView.isHidden = isSmallScreenSize
-  }
-
-  func applyDefaultStyle() {
-    accessibilityTraits.remove(.selected)
-    accessibilityHint = "Tap to select"
-
-    numberLabel.textColor = .label
-    selectionBackgroundView.isHidden = true
-  }
+    
+    var isSmallScreenSize: Bool {
+        let isCompact = traitCollection.horizontalSizeClass == .compact
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let widthGreaterThanHeight =
+        UIScreen.main.bounds.width > UIScreen.main.bounds.height
+        
+        return isCompact && (smallWidth || widthGreaterThanHeight)
+    }
+    
+    func applySelectedStyle() {
+        accessibilityTraits.insert(.selected)
+        accessibilityHint = nil
+        
+        numberLabel.textColor = isSmallScreenSize ? .systemRed : .white
+        selectionBackgroundView.isHidden = isSmallScreenSize
+    }
+    
+    func applyDefaultStyle() {
+        accessibilityTraits.remove(.selected)
+        accessibilityHint = "Tap to select"
+        
+        numberLabel.textColor = .label
+        selectionBackgroundView.isHidden = true
+    }
+    
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
@@ -9,11 +9,11 @@ import UIKit
 
 class CalendarViewCell: UICollectionViewCell {
     
-    var day: SearchDayDTO? {
+    var day: Day? {
       didSet {
         guard let day = day else { return }
 
-        numberLabel.text = day.day
+        numberLabel.text = day.number
         accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
         updateSelectionStatus()
       }
@@ -59,18 +59,12 @@ class CalendarViewCell: UICollectionViewCell {
     
     override func layoutSubviews() {
       super.layoutSubviews()
-      
-      // This allows for rotations and trait collection
-      // changes (e.g. entering split view on iPad) to update constraints correctly.
-      // Removing old constraints allows for new ones to be created
-      // regardless of the values of the old ones
+
       NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
 
-      // 1
       let size = traitCollection.horizontalSizeClass == .compact ?
         min(min(frame.width, frame.height) - 10, 60) : 45
 
-      // 2
       NSLayoutConstraint.activate([
         numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
         numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -91,18 +85,17 @@ class CalendarViewCell: UICollectionViewCell {
 
 // MARK: - Appearance
 private extension CalendarViewCell {
-  // 1
+  
   func updateSelectionStatus() {
     guard let day = day else { return }
 
     if day.isSelected {
       applySelectedStyle()
     } else {
-        applyDefaultStyle(isWithinDisplayedMonth: day.isOccupied)
+        applyDefaultStyle()
     }
   }
 
-  // 2
   var isSmallScreenSize: Bool {
     let isCompact = traitCollection.horizontalSizeClass == .compact
     let smallWidth = UIScreen.main.bounds.width <= 350
@@ -112,7 +105,6 @@ private extension CalendarViewCell {
     return isCompact && (smallWidth || widthGreaterThanHeight)
   }
 
-  // 3
   func applySelectedStyle() {
     accessibilityTraits.insert(.selected)
     accessibilityHint = nil
@@ -121,12 +113,11 @@ private extension CalendarViewCell {
     selectionBackgroundView.isHidden = isSmallScreenSize
   }
 
-  // 4
-  func applyDefaultStyle(isWithinDisplayedMonth: Bool) {
+  func applyDefaultStyle() {
     accessibilityTraits.remove(.selected)
     accessibilityHint = "Tap to select"
 
-    numberLabel.textColor = isWithinDisplayedMonth ? .label : .secondaryLabel
+    numberLabel.textColor = .label
     selectionBackgroundView.isHidden = true
   }
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -17,10 +17,9 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         layout.minimumLineSpacing = 0
         layout.minimumInteritemSpacing = 0
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.isScrollEnabled = true
-        collectionView.isPagingEnabled = true
         collectionView.backgroundColor = .systemBackground
         collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.showsVerticalScrollIndicator = false
         return collectionView
     }()
     
@@ -42,6 +41,7 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
     
     private func setUpCollectionViewDelegates() {
         collectionView.register(CalendarViewCell.self, forCellWithReuseIdentifier: CalendarViewCell.reuseIdentifier)
+        collectionView.register(CalendarHearderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: CalendarHearderView.reuseIdentifier)
         collectionView.delegate = self
         collectionView.dataSource = self
     }
@@ -59,7 +59,7 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         
         collectionView.snp.makeConstraints {
             $0.top.leading.trailing.equalTo(view.readableContentGuide)
-            $0.height.equalTo(view.snp.height).multipliedBy(0.6)
+            $0.height.equalTo(view.snp.height).multipliedBy(0.5)
         }
     }
     
@@ -86,25 +86,50 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
 
 extension CalendarViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return calendarModel.days.count
+        return calendarModel.month[section].result.count
     }
     
-//    func numberOfSections(in collectionView: UICollectionView) -> Int {
-//        calendarModel.count
-//    }
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        calendarModel.month.count
+    }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewCell.reuseIdentifier, for: indexPath) as? CalendarViewCell else {
-            return UICollectionViewCell()
-        }
-        let day = calendarModel.days[indexPath.row]
+        guard let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewCell.reuseIdentifier, for: indexPath) as? CalendarViewCell else { return UICollectionViewCell() }
+        let day = calendarModel.month[indexPath.section].result[indexPath.row]
         cell.day = day
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            guard
+                let headerView = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier:  CalendarHearderView.reuseIdentifier,
+                    for: indexPath) as? CalendarHearderView
+            else { return UICollectionReusableView() }
+            
+            let date = calendarModel.month[indexPath.section]
+                .result.last?.date
+            headerView.baseDate = date
+            return headerView
+        default:
+            return UICollectionReusableView()
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        let width: CGFloat = self.collectionView.frame.width
+        let height: CGFloat = 60
+        return CGSize(width: width, height: height)
     }
 }
 
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: self.collectionView.frame.width / 7, height: self.collectionView.frame.width / 7)
+        let width: Int = Int(self.collectionView.frame.width / 7)
+        let height: Int = 50
+        return CGSize(width: width, height: height)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
+++ b/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
@@ -11,6 +11,7 @@ struct Day {
     let date: Date
     let number: String
     let isSelected: Bool
+    let isWithInDisplayedMonth: Bool
     var fadeState: FadeState = .none
 }
 

--- a/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
+++ b/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
@@ -1,0 +1,19 @@
+//
+//  Day.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/06/01.
+//
+
+import Foundation
+
+struct Day {
+    let date: Date
+    let number: String
+    let isSelected: Bool
+    var fadeState: FadeState = .none
+}
+
+enum FadeState {
+    case left, right, fill, none
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
@@ -15,24 +15,20 @@ class CalendarModel {
     
     private var baseDate: Date {
         didSet {
-            days = generateDaysInMonth(for: baseDate)
+            month = generate12month(for: baseDate)
             self.onUpdate()
         }
     }
     
-    lazy var days = generateDaysInMonth(for: baseDate)
+    lazy var month = generate12month(for: baseDate)
     
-    private var numberOfWeeksInBaseDate: Int {
+    var numberOfWeeksInBaseDate: Int {
       calendar.range(of: .weekOfMonth, in: .month, for: baseDate)?.count ?? 0
     }
     
     var onUpdate: () -> Void = { }
     
-    let calendar: Calendar = {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale(identifier: "ko_kr")
-        return calendar
-    }()
+    let calendar: Calendar = Calendar.current
     
     private lazy var dateFormatter: DateFormatter = {
       let dateFormatter = DateFormatter()
@@ -42,38 +38,54 @@ class CalendarModel {
     
     init(baseDate: Date) {
         self.baseDate = baseDate
+
     }
     
-    private func makeMonthMetadata(for baseDate: Date) -> Result<MonthMetadata, CalendarDateError> {
+    func generate12month(for baseDate: Date) -> [Month] {
+        
+        var year: [Month] = []
+        for addMonth in stride(from: 0, to: 11, by: 1) {
+            if let month = calendar.date(byAdding: .month, value: addMonth, to: baseDate) {
+                year.append(generateDaysInMonth(for: month))
+            }
+        }
+        // 그 이중 배열을 내보냄 근데 그 기준일이 언제임, 그 기준일을 가지고 제일 처음에 보여줄 달을 짜는 로직도 힘겹겠네.. 가장 처음 지금 있는 달이 나와야 할테니까...
+        return year
+    }
+    
+    private func generateMonthMetadata(for baseDate: Date) -> Result<MonthMetadata, CalendarDateError> {
         guard let daysCountInMonth = calendar.range(of: .day, in: .month, for: baseDate)?.count,
               let firstDayInMonth = calendar.date(
-                from: calendar.dateComponents([.year, .month, .hour], from: baseDate)) else {
+                from: calendar.dateComponents([.year, .month], from: baseDate)) else {
                     return .failure(CalendarDateError.monthMetadataError)
                 }
         let firstDayWeekday = calendar.component(.weekday, from: firstDayInMonth)
         return .success(MonthMetadata(numberOfDays: daysCountInMonth, firstDay: firstDayInMonth, firstDayWeekday: firstDayWeekday))
     }
     
-    func generateDaysInMonth(for baseDate: Date) -> [Day] {
-        switch makeMonthMetadata(for: baseDate) {
+    private func generateDaysInMonth(for baseDate: Date) -> Month {
+        switch generateMonthMetadata(for: baseDate) {
         case .success(let metadata):
             let daysCountInMonth = metadata.numberOfDays
             let offsetInInitailRow = metadata.firstDayWeekday
             let firstDayOfMonth = metadata.firstDay
             
-            let days: [Day] = (1..<daysCountInMonth).map { day in
-                let dayOffset = day - offsetInInitailRow
-                return generateDay(offsetBy: dayOffset, for: firstDayOfMonth)
+            let days: [Day] = (1..<daysCountInMonth + offsetInInitailRow).map { day in
+                let isWithinDisplayedMonth = day >= offsetInInitailRow
+                let dayOffset = isWithinDisplayedMonth ? day - offsetInInitailRow : -(offsetInInitailRow - day)
+                return generateDay(offsetBy: dayOffset,
+                                   for: firstDayOfMonth,
+                                   isWithinDisplayedMonth: isWithinDisplayedMonth)
             }
-            return days
+            return Month(date: baseDate, result: days)
         case .failure(let error):
-            dump(error)
-            return []
+            fatalError("failed making month ==> \(dump(error))")
         }
     }
     
     private func generateDay(offsetBy dayOffset: Int,
-                             for baseDate: Date)  -> Day {
+                             for baseDate: Date,
+                             isWithinDisplayedMonth: Bool)  -> Day {
         let date = calendar.date(byAdding: .day,
                                  value: dayOffset,
                                  to: baseDate) ?? baseDate
@@ -81,15 +93,46 @@ class CalendarModel {
             return Day(date: date,
                        number: dateFormatter.string(from: date),
                        isSelected: calendar.isDate(date,
-                                                   inSameDayAs: selectedDate))
+                                                   inSameDayAs: selectedDate),
+                        isWithInDisplayedMonth: isWithinDisplayedMonth)
         } else {
             return Day(date: date,
                        number: dateFormatter.string(from: date),
-                       isSelected: false)
+                       isSelected: false,
+                       isWithInDisplayedMonth: isWithinDisplayedMonth)
         }
     }
 }
 
 enum CalendarDateError: Error {
     case monthMetadataError
+}
+
+extension CalendarModel {
+    func shinghaSayMakeDays(for baseDate: Date) -> [Date?] {
+        let component = calendar.dateComponents([.year, .month], from: baseDate)
+        guard let firstDate = calendar.date(from: component),
+              let nextMonthDate = calendar.date(byAdding: .month, value: 1, to: firstDate), // 7월 1일
+              let lastDate = calendar.date(byAdding: .day, value: -1, to: nextMonthDate) else {
+                  return []
+              }
+        let startComponent = calendar.dateComponents([.day, .weekday], from: firstDate)
+        let lastComponent = calendar.dateComponents([.day, .weekday], from: lastDate)
+        guard let lastday = lastComponent.day,
+              let startWeekDay = startComponent.weekday,
+              let lastWeekDay = lastComponent.weekday else {
+                  return []
+              }
+        var dates: [Date?] = (0..<lastday).map { addDay in
+            calendar.date(byAdding: .day, value: addDay, to: firstDate)
+        }
+        (0..<startWeekDay - 1).forEach { _ in dates.insert(nil, at: 0) }
+        (lastWeekDay - 1..<6).forEach { _ in dates.append(nil) }
+        return dates
+    }
+}
+
+struct Month {
+    let date: Date
+    let result: [Day]
 }

--- a/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
@@ -1,0 +1,95 @@
+//
+//  CalendarModel.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/06/01.
+//
+
+import Foundation
+
+class CalendarModel {
+    
+    let selectedDateChaged: (Date) -> Void = { _ in }
+    
+    var selectedDate: Date?
+    
+    private var baseDate: Date {
+        didSet {
+            days = generateDaysInMonth(for: baseDate)
+            self.onUpdate()
+        }
+    }
+    
+    lazy var days = generateDaysInMonth(for: baseDate)
+    
+    private var numberOfWeeksInBaseDate: Int {
+      calendar.range(of: .weekOfMonth, in: .month, for: baseDate)?.count ?? 0
+    }
+    
+    var onUpdate: () -> Void = { }
+    
+    let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_kr")
+        return calendar
+    }()
+    
+    private lazy var dateFormatter: DateFormatter = {
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "d"
+      return dateFormatter
+    }()
+    
+    init(baseDate: Date) {
+        self.baseDate = baseDate
+    }
+    
+    private func makeMonthMetadata(for baseDate: Date) -> Result<MonthMetadata, CalendarDateError> {
+        guard let daysCountInMonth = calendar.range(of: .day, in: .month, for: baseDate)?.count,
+              let firstDayInMonth = calendar.date(
+                from: calendar.dateComponents([.year, .month, .hour], from: baseDate)) else {
+                    return .failure(CalendarDateError.monthMetadataError)
+                }
+        let firstDayWeekday = calendar.component(.weekday, from: firstDayInMonth)
+        return .success(MonthMetadata(numberOfDays: daysCountInMonth, firstDay: firstDayInMonth, firstDayWeekday: firstDayWeekday))
+    }
+    
+    func generateDaysInMonth(for baseDate: Date) -> [Day] {
+        switch makeMonthMetadata(for: baseDate) {
+        case .success(let metadata):
+            let daysCountInMonth = metadata.numberOfDays
+            let offsetInInitailRow = metadata.firstDayWeekday
+            let firstDayOfMonth = metadata.firstDay
+            
+            let days: [Day] = (1..<daysCountInMonth).map { day in
+                let dayOffset = day - offsetInInitailRow
+                return generateDay(offsetBy: dayOffset, for: firstDayOfMonth)
+            }
+            return days
+        case .failure(let error):
+            dump(error)
+            return []
+        }
+    }
+    
+    private func generateDay(offsetBy dayOffset: Int,
+                             for baseDate: Date)  -> Day {
+        let date = calendar.date(byAdding: .day,
+                                 value: dayOffset,
+                                 to: baseDate) ?? baseDate
+        if let selectedDate = selectedDate {
+            return Day(date: date,
+                       number: dateFormatter.string(from: date),
+                       isSelected: calendar.isDate(date,
+                                                   inSameDayAs: selectedDate))
+        } else {
+            return Day(date: date,
+                       number: dateFormatter.string(from: date),
+                       isSelected: false)
+        }
+    }
+}
+
+enum CalendarDateError: Error {
+    case monthMetadataError
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/MonthMetadata.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/MonthMetadata.swift
@@ -1,0 +1,14 @@
+//
+//  MonthMetadata.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/06/01.
+//
+
+import Foundation
+
+struct MonthMetadata {
+    let numberOfDays: Int
+    let firstDay: Date
+    let firstDayWeekday: Int
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/SearchCalendarModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/SearchCalendarModel.swift
@@ -9,6 +9,26 @@ import Foundation
 
 class SearchCalendarModel {
     
+    private(set) var resultArray: [CalendarResult] = [] {
+        didSet {
+            self.onUpdateAYear()
+        }
+    }
+    
+    private(set) var date = Date()
+    
+    var count: Int { resultArray.count }
+    
+    var onUpdateAYear: () -> Void = { }
+    
+    func make12month(baseDate: Date) {
+        for _ in 0..<12 {
+            let nextMonthResult = getNextMonthDays(from: baseDate)
+            self.resultArray.append(nextMonthResult)
+            self.date = nextMonthResult.date
+        }
+    }
+    
     private(set) var localCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
         calendar.locale = Locale(identifier: "ko_kr")
@@ -47,7 +67,7 @@ class SearchCalendarModel {
         }
         
         var dateComponent = localCalendar.dateComponents([.year,.month,.day,.hour], from: dateMonthMoved)
-        dateComponent.day = 2
+//        dateComponent.day = 2
         dateComponent.hour = 0
         
         guard

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -30,7 +30,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(LocationCollectionViewCell.self, forCellWithReuseIdentifier: LocationCollectionViewCell.reuseIdentifier)
         collectionView.register(HeaderReusableView.self,
-                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderReusableView.ID)
+                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderReusableView.reuseIdentifier)
         return collectionView
     }()
     
@@ -134,7 +134,7 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
     UICollectionReusableView {
         switch kind {
         case UICollectionView.elementKindSectionHeader:
-            let headerView = nearbyLoactionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HeaderReusableView.ID, for: indexPath)
+            let headerView = nearbyLoactionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HeaderReusableView.reuseIdentifier, for: indexPath)
             return headerView
         default:
             assert(false, "header, footer, withReuseIdentifier 를 확인하세요.")

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -24,7 +24,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         return searchController
     }()
         
-    lazy var nearbyLoactionView: UICollectionView = {
+    private(set) var nearbyLoactionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -53,7 +53,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         view.addSubview(nearbyLoactionView)
         
         nearbyLoactionView.snp.makeConstraints {
-            $0.top.trailing.leading.bottom.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
     
@@ -78,7 +78,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        attribute()
+        navigationController?.isToolbarHidden = true
     }
     
 }
@@ -125,8 +125,8 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
         guard let item = model[indexPath.row] else {
             return UICollectionViewCell()
         }
-        cell.cityName.text = item.destination
-        cell.spendingTime.text = (item as? PopularCityInfomation)?.distance
+        
+        cell.updateInfomation(item)
         return cell
     }
     
@@ -142,14 +142,10 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let reservationModel = ReservationModel()
         guard let cell = collectionView.cellForItem(at: indexPath) as? LocationCollectionViewCell else {
             return
         }
-        let backButton = UIBarButtonItem(title: "뒤로", style: .plain,
-                                         target: self, action: nil)
-        backButton.tintColor = .gray
-        self.navigationItem.backBarButtonItem = backButton
+        let reservationModel = ReservationModel()
         reservationModel.location = cell.cityName.text
         let nextVC = CalendarViewController(reservationModel: reservationModel)
         self.navigationController?.pushViewController(nextVC, animated: true)

--- a/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
@@ -14,6 +14,12 @@ class SearchViewController: BackgroundViewController, CommonViewControllerProtoc
         case searchMainBody
     }
     
+    private let searchBar: UISearchBar = {
+        let searchBar = UISearchBar()
+        searchBar.placeholder = "어디로 여행가세요?"
+        return searchBar
+    }()
+    
     private var searchMainCollectionViewLayout: UICollectionViewLayout {
         let inset = NSDirectionalEdgeInsets(
             top: 2, leading: 2, bottom: 2, trailing: 2)
@@ -143,12 +149,6 @@ class SearchViewController: BackgroundViewController, CommonViewControllerProtoc
         return collectionView
     }()
   
-    private let searchBar: UISearchBar = {
-        let searchBar = UISearchBar()
-        searchBar.placeholder = "어디로 여행가세요?"
-        return searchBar
-    }()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         layout()
@@ -181,11 +181,6 @@ extension SearchViewController: UISearchBarDelegate {
     
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         searchBar.resignFirstResponder()
-        let backButton = UIBarButtonItem(title: "뒤로", style: .plain,
-                                         target: self, action: nil)
-        backButton.tintColor = .gray
-        self.navigationItem.backBarButtonItem = backButton
-    
         let locationViewController = LocationViewController()
         locationViewController.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(locationViewController, animated: false)

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
@@ -19,7 +19,6 @@ class LocationCollectionViewCell: UICollectionViewCell {
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = 6
-//        imageView.frame = CGRect(x: 0, y: 0, width: 64, height: 64)
         return imageView
     }()
     
@@ -66,5 +65,10 @@ class LocationCollectionViewCell: UICollectionViewCell {
             $0.leading.equalTo(cityImage.snp.trailing).offset(16)
             $0.centerY.equalToSuperview()
         }
+    }
+    
+    func updateInfomation(_ info: CityInformation) {
+        cityName.text = info.destination
+        spendingTime.text = (info as? PopularCityInfomation)?.distance
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/SearchCellCommonType.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/SearchCellCommonType.swift
@@ -12,6 +12,6 @@ protocol SearchCellCommonType: UICollectionViewCell {
     func setData(model: SearchViewModel)
 }
 
-extension UICollectionViewCell {
-    static var reuseIdentifier: String { String(describing: Self.self) }
-}
+//extension UICollectionViewCell {
+////    static var reuseIdentifier: String { String(describing: Self.self) }
+//}

--- a/iOS/Airbnb/Airbnb/Source/AppDelegate.swift
+++ b/iOS/Airbnb/Airbnb/Source/AppDelegate.swift
@@ -13,4 +13,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-


### PR DESCRIPTION
# 작업 내용

- [x] 1년 구현
- [x] 헤더뷰 구현
- [ ] 사용하지 않는 파일 `SearchDayDTO` 등 삭제, @SangHwi-Back 과 상의 필요
- [ ] 탭 작업 안됨 앞으로 할 일
- [ ] 스크롤 에지가 날때 쯤 모델에게 새로운 값을 업데이트 시킬지 결정 하면 할 수 있을듯? 
# Simulation

![Simulator Screen Recording - iPhone 13 - 2022-06-02 at 01 35 19](https://user-images.githubusercontent.com/50472122/171455656-8438943f-ef76-4ceb-a7a6-24d492051ca7.gif)

# 작업업하다 막힌 부분

* 달의 첫쨋날을 반영하는 로직에서 애를 먹음
* 메모리 릭이 나고 있는 것 같은 의심 (4 페이지 짜리 앱이 80MB 를 먹고 있습니다. 비사아아아앙!!!)
* header view 가 값이 제대로 전달이 되지 않는 문제 
  * result[indexPath.row] 대신, result.last 를 사용해서 해결
* calender.date(), calendar.dateComponents() 등 이름도 비슷하고 용도도 햇갈려서 한번 정리가 필요했음